### PR TITLE
Add geotab:selectionStatus display and control to table

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -222,11 +222,23 @@ button:active {
 #data-table tr.active {
   background-color: #ffff00;
 }
+#data-table tr.hoveractive {
+  background-color: #ffff9f;
+}
+#data-table tr.hoverinactive {
+  background-color: #ffffcf;
+}
 #data-table tr:nth-child(odd) {
   background-color: #f3f6fa;
 }
 #data-table tr.active:nth-child(odd) {
   background-color: #f3f600;
+}
+#data-table tr.hoveractive:nth-child(odd) {
+  background-color: #f3f69a;
+}
+#data-table tr.hoverinactive:nth-child(odd) {
+  background-color: #f3f6ca;
 }
 #data-table tr td {
   text-align: left;

--- a/src/App.css
+++ b/src/App.css
@@ -222,10 +222,10 @@ button:active {
 #data-table tr.active {
   background-color: #ffff00;
 }
-#data-table tr.hoveractive {
+#data-table tr.hoveractive, #data-table tr.active:hover {
   background-color: #ffff9f;
 }
-#data-table tr.hoverinactive {
+#data-table tr.hoverinactive, #data-table tr:hover {
   background-color: #ffffcf;
 }
 #data-table tr:nth-child(odd) {
@@ -234,10 +234,10 @@ button:active {
 #data-table tr.active:nth-child(odd) {
   background-color: #f3f600;
 }
-#data-table tr.hoveractive:nth-child(odd) {
+#data-table tr.hoveractive:nth-child(odd), #data-table tr.active:hover:nth-child(odd) {
   background-color: #f3f69a;
 }
-#data-table tr.hoverinactive:nth-child(odd) {
+#data-table tr.hoverinactive:nth-child(odd), #data-table tr:hover:nth-child(odd) {
   background-color: #f3f6ca;
 }
 #data-table tr td {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { evaluateFilter } from './filter';
 import { GeotabLogo } from './icon/GeotabLogo';
 import { GoogleLogin } from './google-drive'
 import {getFeatures, getPropertiesUnion} from './algorithm'
+import { FieldTypeDescription } from './fieldtype';
+import { Column } from './column'
 
 interface IAppProps {
 }
@@ -44,15 +46,7 @@ class App extends React.Component<IAppProps, IState> {
         });
       },
       setColumns: (newColumns) => {
-        // ensure pseudo-column "geotab:selectionStatus" is always present
-        if (!newColumns.some((c) => c.name === "geotab:selectionStatus")) {
-          newColumns.push({
-            name: "geotab:selectionStatus",
-            visible: false,
-            type: "string",
-          })
-        }
-        this.setState({columns: newColumns})
+        this.setState({columns: withSelectionStatus(newColumns)})
       },
       setActive: (newActive) => {this.setState({active: newActive})},
       setSymbology: (newSymbology) => {this.setState({symbology: newSymbology})},
@@ -65,7 +59,7 @@ class App extends React.Component<IAppProps, IState> {
                 data: flattened,
                 filter: json.geotabMetadata.filter,
                 filteredData: flattened.filter((row) => evaluateFilter(row, json.geotabMetadata.filter)),
-                columns: json.geotabMetadata.columns,
+                columns: withSelectionStatus(json.geotabMetadata.columns),
                 active: null,
                 symbology: json.geotabMetadata.symbology,
               });
@@ -73,7 +67,7 @@ class App extends React.Component<IAppProps, IState> {
               this.setState({
                 data: this.state ? this.state.data.concat(flattened) : flattened,
                 filteredData: flattened.filter((row) => evaluateFilter(row, this.state?.filter)),
-                columns: getPropertiesUnion(flattened, this.state?.columns),
+                columns: withSelectionStatus(getPropertiesUnion(flattened, this.state?.columns)),
                 active: null,
               });
             }
@@ -82,7 +76,7 @@ class App extends React.Component<IAppProps, IState> {
             this.setState({
               data: newData,
               filteredData: newData.filter((row) => evaluateFilter(row, this.state?.filter)),
-              columns: getPropertiesUnion(newData, this.state?.columns),
+              columns: withSelectionStatus(getPropertiesUnion(newData, this.state?.columns)),
               active: null,
             });
           }
@@ -140,6 +134,19 @@ function AppBody() {
       <TabView />
     </div>
   );
+}
+
+function withSelectionStatus(columns:Column[]) {
+  const newColumns = columns.slice();
+  // ensure pseudo-column "geotab:selectionStatus" is always present
+  if (!newColumns.some((c) => c.name === "geotab:selectionStatus")) {
+    newColumns.push({
+      name: "geotab:selectionStatus",
+      visible: false,
+      type: FieldTypeDescription.String,
+    })
+  }
+  return newColumns;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,13 +26,11 @@ class App extends React.Component<IAppProps, IState> {
       filter: null,
       filteredData: [],
       columns: [],
-      active: null,
       symbology: null,
       setData: this.setData.bind(this),
       setFilter: this.setFilter.bind(this),
       setDataAndFilter: this.setDataAndFilter.bind(this),
       setColumns: this.setColumns.bind(this),
-      setActive: this.setActive.bind(this),
       setSymbology: this.setSymbology.bind(this),
       setFromJson: this.setFromJson.bind(this),
     };
@@ -64,10 +62,6 @@ class App extends React.Component<IAppProps, IState> {
   setColumns(newColumnsOrUpdater:UpdaterOrValue<Column[]>) {
     const newColumns = getValueFromUpdaterOrValue(newColumnsOrUpdater, this.state?.columns);
     this.setState({columns: withSelectionStatus(newColumns ?? [])});
-  }
-  setActive(newActiveOrUpdater:UpdaterOrValue<string|null>) {
-    const newActive = getValueFromUpdaterOrValue(newActiveOrUpdater, this.state?.active);
-    this.setState({active: newActive});
   }
   setSymbology(newSymbologyOrUpdater:UpdaterOrValue<Symbology|null>) {
     const newSymbology = getValueFromUpdaterOrValue(newSymbologyOrUpdater, this.state?.symbology);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,16 @@
 import React, {useContext} from 'react';
 import {BrowserRouter} from 'react-router-dom'
+import * as GeoJson from './geojson-types'
 import './App.css';
 import TabView from './tabview'
-import {DataContextType, DataContext} from './dataContext'
-import { evaluateFilter } from './filter';
+import {DataContextType, DataContext, UpdaterOrValue, getValueFromUpdaterOrValue, GeotabMetadata} from './dataContext'
+import { ConditionGroup, evaluateFilter } from './filter';
 import { GeotabLogo } from './icon/GeotabLogo';
 import { GoogleLogin } from './google-drive'
 import {getFeatures, getPropertiesUnion} from './algorithm'
 import { FieldTypeDescription } from './fieldtype';
 import { Column } from './column'
+import { Symbology } from './painter'
 
 interface IAppProps {
 }
@@ -26,63 +28,82 @@ class App extends React.Component<IAppProps, IState> {
       columns: [],
       active: null,
       symbology: null,
-      setData: (newData) => {
-        this.setState({
-          data: newData,
-          filteredData: newData.filter((row) => evaluateFilter(row, this.state?.filter))
-        });
-      },
-      setFilter: (newFilter) => {
-        this.setState({
-          filter: newFilter,
-          filteredData: this.state?.data.filter((row) => evaluateFilter(row, newFilter))
-        });
-      },
-      setDataAndFilter: (newData, newFilter) => {
-        this.setState({
-          data: newData,
-          filter: newFilter,
-          filteredData: newData.filter((row) => evaluateFilter(row, newFilter))
-        });
-      },
-      setColumns: (newColumns) => {
-        this.setState({columns: withSelectionStatus(newColumns)})
-      },
-      setActive: (newActive) => {this.setState({active: newActive})},
-      setSymbology: (newSymbology) => {this.setState({symbology: newSymbology})},
-      setFromJson: (json) => {
-        const flattened = getFeatures(json);
-        if (flattened.length) {
-          if (this.state && this.state.data.length === 0) {
-            if (json.geotabMetadata) {
-              this.setState({
-                data: flattened,
-                filter: json.geotabMetadata.filter,
-                filteredData: flattened.filter((row) => evaluateFilter(row, json.geotabMetadata.filter)),
-                columns: withSelectionStatus(json.geotabMetadata.columns),
-                active: null,
-                symbology: json.geotabMetadata.symbology,
-              });
-            } else {
-              this.setState({
-                data: this.state ? this.state.data.concat(flattened) : flattened,
-                filteredData: flattened.filter((row) => evaluateFilter(row, this.state?.filter)),
-                columns: withSelectionStatus(getPropertiesUnion(flattened, this.state?.columns)),
-                active: null,
-              });
-            }
-          } else {
-            const newData = this.state ? this.state.data.concat(flattened) : flattened;
-            this.setState({
-              data: newData,
-              filteredData: newData.filter((row) => evaluateFilter(row, this.state?.filter)),
-              columns: withSelectionStatus(getPropertiesUnion(newData, this.state?.columns)),
-              active: null,
-            });
-          }
-        }
-      },
+      setData: this.setData.bind(this),
+      setFilter: this.setFilter.bind(this),
+      setDataAndFilter: this.setDataAndFilter.bind(this),
+      setColumns: this.setColumns.bind(this),
+      setActive: this.setActive.bind(this),
+      setSymbology: this.setSymbology.bind(this),
+      setFromJson: this.setFromJson.bind(this),
     };
+  }
+
+  setData(newDataOrUpdator:UpdaterOrValue<GeoJson.Feature[]>) {
+    const newData = getValueFromUpdaterOrValue(newDataOrUpdator, this.state?.data);
+    this.setState({
+      data: newData,
+      filteredData: newData?.filter((row) => evaluateFilter(row, this.state?.filter))
+    });
+  }
+  setFilter(newFilterOrUpdater:UpdaterOrValue<ConditionGroup|undefined>) {
+    const newFilter = getValueFromUpdaterOrValue(newFilterOrUpdater, this.state?.filter);
+    this.setState({
+      filter: newFilter,
+      filteredData: this.state?.data.filter((row) => evaluateFilter(row, newFilter))
+    })
+  }
+  setDataAndFilter(newDataOrUpdator:UpdaterOrValue<GeoJson.Feature[]>, newFilterOrUpdater:UpdaterOrValue<ConditionGroup|undefined>) {
+    const newData = getValueFromUpdaterOrValue(newDataOrUpdator, this.state?.data);
+    const newFilter = getValueFromUpdaterOrValue(newFilterOrUpdater, this.state?.filter);
+    this.setState({
+      data: newData,
+      filter: newFilter,
+      filteredData: newData?.filter((row) => evaluateFilter(row, newFilter))
+    });
+  }
+  setColumns(newColumnsOrUpdater:UpdaterOrValue<Column[]>) {
+    const newColumns = getValueFromUpdaterOrValue(newColumnsOrUpdater, this.state?.columns);
+    this.setState({columns: withSelectionStatus(newColumns ?? [])});
+  }
+  setActive(newActiveOrUpdater:UpdaterOrValue<string|null>) {
+    const newActive = getValueFromUpdaterOrValue(newActiveOrUpdater, this.state?.active);
+    this.setState({active: newActive});
+  }
+  setSymbology(newSymbologyOrUpdater:UpdaterOrValue<Symbology|null>) {
+    const newSymbology = getValueFromUpdaterOrValue(newSymbologyOrUpdater, this.state?.symbology);
+    this.setState({symbology: newSymbology});
+  }
+  setFromJson(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) {
+    const flattened = getFeatures(json);
+    if (flattened.length) {
+      if (this.state && this.state.data.length === 0) {
+        if (json.geotabMetadata) {
+          this.setState({
+            data: flattened,
+            filter: json.geotabMetadata.filter,
+            filteredData: flattened.filter((row) => evaluateFilter(row, json.geotabMetadata.filter)),
+            columns: withSelectionStatus(json.geotabMetadata.columns),
+            active: null,
+            symbology: json.geotabMetadata.symbology,
+          });
+        } else {
+          this.setState({
+            data: this.state ? this.state.data.concat(flattened) : flattened,
+            filteredData: flattened.filter((row) => evaluateFilter(row, this.state?.filter)),
+            columns: withSelectionStatus(getPropertiesUnion(flattened, this.state?.columns)),
+            active: null,
+          });
+        }
+      } else {
+        const newData = this.state ? this.state.data.concat(flattened) : flattened;
+        this.setState({
+          data: newData,
+          filteredData: newData.filter((row) => evaluateFilter(row, this.state?.filter)),
+          columns: withSelectionStatus(getPropertiesUnion(newData, this.state?.columns)),
+          active: null,
+        });
+      }
+    }
   }
 
   render() {

--- a/src/dataContext.tsx
+++ b/src/dataContext.tsx
@@ -1,26 +1,43 @@
 import React from 'react';
 import * as GeoJson from './geojson-types'
 import {Column} from './column'
+import {ConditionGroup} from './filter'
+import {Symbology} from './painter'
 
 export type GeotabMetadata = {
   columns: Column[], // TODO define column definition type
   filter: any, // TODO define filter type
   symbology: any, // TODO define symbology definition type
 }
+
+export type Updater<T> = (old:T) => T;
+export type UpdaterOrValue<T> = Updater<T>|T;
+
+export function getValueFromUpdaterOrValue<T>(updaterOrValue:UpdaterOrValue<T>, currentValue:T|undefined) : T|undefined {
+  if (typeof updaterOrValue === "function") {
+    if (currentValue === undefined) {
+      return undefined;
+    }
+    return (updaterOrValue as Updater<T>)(currentValue);
+  } else {
+    return updaterOrValue;
+  }
+}
+
 export type DataContextType = {
   data: GeoJson.Feature[],
   filter: any, // TODO define filter type
   filteredData: GeoJson.Feature[],
   columns: Column[],
   active: string | null,
-  symbology: any, // TODO define symbology definition type
-  setData: {(newData:GeoJson.Feature[]) : void},
-  setFilter: {(newFilter:any) : void},
-  setDataAndFilter: {(newData:GeoJson.Feature[], newFilter:any) : void},
-  setColumns: {(newColumns:any[]) : void},
-  setActive: {(newActive?:string) : void},
-  setSymbology: {(newSymbology:any) : void},
-  setFromJson: {(json:GeoJson.Feature[] & {geotabMetadata:GeotabMetadata}) : void},
+  symbology: Symbology | null,
+  setData: {(updaterOrValue:UpdaterOrValue<GeoJson.Feature[]>) : void},
+  setFilter: {(newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
+  setDataAndFilter: {(newData:UpdaterOrValue<GeoJson.Feature[]>, newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
+  setColumns: {(newColumns:UpdaterOrValue<Column[]>) : void},
+  setActive: {(newActive:UpdaterOrValue<string|null>) : void},
+  setSymbology: {(newSymbology:UpdaterOrValue<Symbology|null>) : void},
+  setFromJson: {(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) : void},
 } | null;
 
 export const DataContext = React.createContext<DataContextType>(null);

--- a/src/dataContext.tsx
+++ b/src/dataContext.tsx
@@ -29,13 +29,11 @@ export type DataContextType = {
   filter: any, // TODO define filter type
   filteredData: GeoJson.Feature[],
   columns: Column[],
-  active: string | null,
   symbology: Symbology | null,
   setData: {(updaterOrValue:UpdaterOrValue<GeoJson.Feature[]>) : void},
   setFilter: {(newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setDataAndFilter: {(newData:UpdaterOrValue<GeoJson.Feature[]>, newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setColumns: {(newColumns:UpdaterOrValue<Column[]>) : void},
-  setActive: {(newActive:UpdaterOrValue<string|null>) : void},
   setSymbology: {(newSymbology:UpdaterOrValue<Symbology|null>) : void},
   setFromJson: {(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) : void},
 } | null;

--- a/src/mapview.js
+++ b/src/mapview.js
@@ -7,6 +7,7 @@ import {DataContext} from './dataContext'
 import {getCentralCoord, hashCode, getFeatureListBounds} from './algorithm'
 import mapLayers from './maplayers'
 import {painter} from './painter'
+import {onMouseOver, onMouseOut, onMouseClick} from './selection'
 
 function MapView(props) {
     const context = useContext(DataContext);
@@ -40,36 +41,24 @@ function MapView(props) {
                 mouseover: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
                   restyleLayer(feature, e.target);
-                  context.setData(data => data.map(f => f.id !== feature.id
-                    ? f
-                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive"}}
-                    ));
+                  context.setData(onMouseOver.bind(null,feature.id));
                 },
               })
               layer.on({
                 click: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "hoveractive" ? "hoverinactive" : "hoveractive";
                   restyleLayer(feature, e.target);
-                  context.setData(data => data.map(f => f.id !== feature.id
-                    ? f
-                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "hoveractive" ? "hoverinactive" : "hoveractive"}}
-                    ));
+                  context.setData(onMouseClick.bind(null,feature.id));
                 },
                 mouseout: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"].substring(5);
                   restyleLayer(feature, e.target);
-                  context.setData(data => data.map(f => f.id !== feature.id
-                    ? f
-                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"].substring(5)}}
-                    ));
+                  context.setData(onMouseOut.bind(null,feature.id));
                   e.target.once({
                     mouseover: (e) => {
                       feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
                       restyleLayer(feature, e.target);
-                      context.setData(data => data.map(f => f.id !== feature.id
-                        ? f
-                        : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive"}}
-                        ));
+                      context.setData(onMouseOver.bind(null,feature.id));
                     },
                   })
                 },

--- a/src/mapview.js
+++ b/src/mapview.js
@@ -40,20 +40,36 @@ function MapView(props) {
                 mouseover: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
                   restyleLayer(feature, e.target);
+                  context.setData(data => data.map(f => f.id !== feature.id
+                    ? f
+                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive"}}
+                    ));
                 },
               })
               layer.on({
                 click: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "hoveractive" ? "hoverinactive" : "hoveractive";
                   restyleLayer(feature, e.target);
+                  context.setData(data => data.map(f => f.id !== feature.id
+                    ? f
+                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "hoveractive" ? "hoverinactive" : "hoveractive"}}
+                    ));
                 },
                 mouseout: (e) => {
                   feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"].substring(5);
                   restyleLayer(feature, e.target);
+                  context.setData(data => data.map(f => f.id !== feature.id
+                    ? f
+                    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"].substring(5)}}
+                    ));
                   e.target.once({
                     mouseover: (e) => {
                       feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
                       restyleLayer(feature, e.target);
+                      context.setData(data => data.map(f => f.id !== feature.id
+                        ? f
+                        : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: f.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive"}}
+                        ));
                     },
                   })
                 },
@@ -64,7 +80,6 @@ function MapView(props) {
                 )
               )
             }} />
-            {context.active !== null && <ActivePopup feature={features.find((feature) => feature.id === context.active)} />}
             <MyLayersControl position="topright" mapLayers={mapLayers} />
           </MapContainer>
         </div>

--- a/src/mapview.js
+++ b/src/mapview.js
@@ -7,7 +7,7 @@ import {DataContext} from './dataContext'
 import {getCentralCoord, hashCode, getFeatureListBounds} from './algorithm'
 import mapLayers from './maplayers'
 import {painter} from './painter'
-import {onMouseOver, onMouseOut, onMouseClick} from './selection'
+import {onMouseOver, onMouseOut, onMouseClick, addHover, removeHover, toggleActive} from './selection'
 
 function MapView(props) {
     const context = useContext(DataContext);
@@ -39,28 +39,28 @@ function MapView(props) {
             onEachFeature={(feature, layer) => {
               layer.once({
                 mouseover: (e) => {
-                  feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
+                  feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
                   restyleLayer(feature, e.target);
                   context.setData(onMouseOver.bind(null,feature.id));
                 },
               })
               layer.on({
                 click: (e) => {
-                  feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "hoveractive" ? "hoverinactive" : "hoveractive";
+                  feature.properties["geotab:selectionStatus"] = toggleActive(feature.properties["geotab:selectionStatus"]);
                   restyleLayer(feature, e.target);
                   context.setData(onMouseClick.bind(null,feature.id));
                 },
                 mouseout: (e) => {
-                  feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"].substring(5);
+                  feature.properties["geotab:selectionStatus"] = removeHover(feature.properties["geotab:selectionStatus"]);
                   restyleLayer(feature, e.target);
-                  context.setData(onMouseOut.bind(null,feature.id));
                   e.target.once({
                     mouseover: (e) => {
-                      feature.properties["geotab:selectionStatus"] = feature.properties["geotab:selectionStatus"] === "active" ? "hoveractive" : "hoverinactive";
+                      feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
                       restyleLayer(feature, e.target);
                       context.setData(onMouseOver.bind(null,feature.id));
                     },
-                  })
+                  });
+                  context.setData(onMouseOut.bind(null,feature.id));
                 },
               })
               layer.bindPopup(

--- a/src/painter.tsx
+++ b/src/painter.tsx
@@ -26,7 +26,7 @@ type SymbologyProperty = {
   type: FieldTypeDescription;
 }
 
-type Symbology = {
+export type Symbology = {
   [index: string] : SymbologyProperty
 }
 

--- a/src/selection.tsx
+++ b/src/selection.tsx
@@ -1,19 +1,19 @@
 import * as GeoJson from './geojson-types'
 
 // Manipulate the selection status to add or remove "hover", or to activate or deactivate
-function addHover(status?:string) {
+export function addHover(status?:string) {
   if (status === undefined) {
     return "hoverinactive";
   }
   return status.includes("hover") ? status : "hover" + status;
 }
-function removeHover(status?:string) {
+export function removeHover(status?:string) {
   if (status === undefined) {
     return "inactive";
   }
   return status.replace("hover","");
 }
-function toggleActive(status?:string) {
+export function toggleActive(status?:string) {
   if (status === undefined) {
     return "active";
   }

--- a/src/selection.tsx
+++ b/src/selection.tsx
@@ -1,0 +1,43 @@
+import * as GeoJson from './geojson-types'
+
+// Manipulate the selection status to add or remove "hover", or to activate or deactivate
+function addHover(status?:string) {
+  if (status === undefined) {
+    return "hoverinactive";
+  }
+  return status.includes("hover") ? status : "hover" + status;
+}
+function removeHover(status?:string) {
+  if (status === undefined) {
+    return "inactive";
+  }
+  return status.replace("hover","");
+}
+function toggleActive(status?:string) {
+  if (status === undefined) {
+    return "active";
+  }
+  return status.includes("inactive") ? status.replace("inactive", "active") : status.replace("active", "inactive");
+}
+// Manipulate a feature list when an action occurs on a certain feature with given ID
+export function onMouseOver(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
+  return data.map(f =>
+    f.id === featureId
+    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: addHover(f.properties["geotab:selectionStatus"])}}
+    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: removeHover(f.properties["geotab:selectionStatus"])}}
+    );
+}
+export function onMouseOut(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
+  return data.map(f =>
+    f.id === featureId
+    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: removeHover(f.properties["geotab:selectionStatus"])}}
+    : f
+    );
+}
+export function onMouseClick(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
+  return data.map(f =>
+    f.id === featureId
+    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: toggleActive(f.properties["geotab:selectionStatus"])}}
+    : f
+    );
+}

--- a/src/table/ColumnContextMenu.tsx
+++ b/src/table/ColumnContextMenu.tsx
@@ -96,11 +96,11 @@ export default function ColumnContextMenu(props:PropsWithChildren<ColumnContextM
     if (context === null) return;
     if (i <= 0) {
       context.setColumns(
-        [{name, visible: true, type: "string"},
+        [{name, visible: true, type: FieldTypeDescription.String},
         ...context.columns]);
     } else {
       context.setColumns([...context.columns.slice(0,i),
-        {name, visible: true, type: "string"},
+        {name, visible: true, type: FieldTypeDescription.String},
         ...context.columns.slice(i,context.columns.length)]);
     }
   };

--- a/src/table/DataTable.tsx
+++ b/src/table/DataTable.tsx
@@ -114,8 +114,6 @@ export default function DataTable() {
             feature={feature}
             rowId={feature.id}
             onChange={handleRowChange}
-            active={context.active !== null && feature.id === context.active}
-            setActive={context.setActive}
             disabled={disabled}
             />)}
       </tbody>

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -27,7 +27,7 @@ export default function TableRow(props:TableRowProps) {
     <tr
       onContextMenu={() => console.log(props.feature)}
       onClick={() => props.setActive(props.feature.id)}
-      className={props.active ? "active" : ""}
+      className={props.feature.properties["geotab:selectionStatus"]}
       >
       <th>
         {1+props.fidx}

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -14,8 +14,6 @@ type TableRowProps = {
   disabled: boolean,
   cellRefs: RefObject<{[colName:string]: HTMLInputElement|null}[]>,
   feature: Feature,
-  active: boolean,
-  setActive: (fid:string) => void,
   onChange: (properties:FeatureProperties, fidx:number) => void,
   handleKeyDown: (e:KeyboardEvent, row:number, col:string) => void,
 }

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -1,9 +1,11 @@
-import {KeyboardEvent, RefObject} from 'react'
+import {KeyboardEvent, RefObject, useContext} from 'react'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import DataTableCell from './DataTableCell'
 import RowContextMenu from './RowContextMenu';
 import {Column} from './../column'
 import {Feature, FeatureProperties} from './../geojson-types'
+import {onMouseOver, onMouseOut, onMouseClick} from '../selection'
+import {DataContext} from '../dataContext'
 
 type TableRowProps = {
   fidx: number,
@@ -19,6 +21,7 @@ type TableRowProps = {
 }
 
 export default function TableRow(props:TableRowProps) {
+  const context = useContext(DataContext);
   const handleCellChange = (value:any, column:Column) => {
     const newFeatureProperties = {...props.feature.properties, [column.name]: value};
     props.onChange(newFeatureProperties, props.fidx);
@@ -26,7 +29,15 @@ export default function TableRow(props:TableRowProps) {
   return (
     <tr
       onContextMenu={() => console.log(props.feature)}
-      onClick={() => props.setActive(props.feature.id)}
+      onClick={(e) => {
+        context?.setData(onMouseClick.bind(null, props.feature.id))}
+      }
+      onMouseOver={(e) => {
+        context?.setData(onMouseOver.bind(null, props.feature.id))}
+      }
+      onMouseOut={(e) => {
+        context?.setData(onMouseOut.bind(null, props.feature.id))}
+      }
       className={props.feature.properties["geotab:selectionStatus"]}
       >
       <th>

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -27,15 +27,9 @@ export default function TableRow(props:TableRowProps) {
   return (
     <tr
       onContextMenu={() => console.log(props.feature)}
-      onClick={(e) => {
-        context?.setData(onMouseClick.bind(null, props.feature.id))}
-      }
-      onMouseOver={(e) => {
-        context?.setData(onMouseOver.bind(null, props.feature.id))}
-      }
-      onMouseOut={(e) => {
-        context?.setData(onMouseOut.bind(null, props.feature.id))}
-      }
+      onClick={(e) => { context?.setData(onMouseClick.bind(null, props.feature.id)) }}
+      onMouseOver={(e) => { context?.setData(onMouseOver.bind(null, props.feature.id)) }}
+      onMouseOut={(e) => { context?.setData(onMouseOut.bind(null, props.feature.id)) }}
       className={props.feature.properties["geotab:selectionStatus"]}
       >
       <th>


### PR DESCRIPTION
The selection status can now be controlled and displayed in the table as well as in the map (via symbology).