### PR TITLE
Use listeners to change display of rows, featuers on mouse events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {BrowserRouter} from 'react-router-dom'
 import * as GeoJson from './geojson-types'
 import './App.css';
 import TabView from './tabview'
-import {DataContextType, DataContext, UpdaterOrValue, getValueFromUpdaterOrValue, GeotabMetadata} from './dataContext'
+import {DataContextType, DataContext, UpdaterOrValue, getValueFromUpdaterOrValue, GeotabMetadata, FeatureListener} from './dataContext'
 import { ConditionGroup, evaluateFilter } from './filter';
 import { GeotabLogo } from './icon/GeotabLogo';
 import { GoogleLogin } from './google-drive'
@@ -27,11 +27,13 @@ class App extends React.Component<IAppProps, IState> {
       filteredData: [],
       columns: [],
       symbology: null,
+      listeners: {},
       setData: this.setData.bind(this),
       setFilter: this.setFilter.bind(this),
       setDataAndFilter: this.setDataAndFilter.bind(this),
       setColumns: this.setColumns.bind(this),
       setSymbology: this.setSymbology.bind(this),
+      setListener: this.setListener.bind(this),
       setFromJson: this.setFromJson.bind(this),
     };
   }
@@ -66,6 +68,14 @@ class App extends React.Component<IAppProps, IState> {
   setSymbology(newSymbologyOrUpdater:UpdaterOrValue<Symbology|null>) {
     const newSymbology = getValueFromUpdaterOrValue(newSymbologyOrUpdater, this.state?.symbology);
     this.setState({symbology: newSymbology});
+  }
+  setListener(id:string, view:"table"|"map", f:FeatureListener) {
+    if (this.state === null) return;
+    if (this.state.listeners[id] === undefined) {
+      this.state.listeners[id] = {map: undefined, table: undefined};
+    }
+    this.state.listeners[id][view] = f;
+    //this.setState({listeners: {...this.state.listeners, [id]: {...this.state.listeners[id], [view]: f}}});
   }
   setFromJson(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) {
     const flattened = getFeatures(json);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,13 +27,13 @@ class App extends React.Component<IAppProps, IState> {
       filteredData: [],
       columns: [],
       symbology: null,
-      listeners: {},
+      featureListeners: {},
       setData: this.setData.bind(this),
       setFilter: this.setFilter.bind(this),
       setDataAndFilter: this.setDataAndFilter.bind(this),
       setColumns: this.setColumns.bind(this),
       setSymbology: this.setSymbology.bind(this),
-      setListener: this.setListener.bind(this),
+      setFeatureListener: this.setListener.bind(this),
       setFromJson: this.setFromJson.bind(this),
     };
   }
@@ -71,11 +71,10 @@ class App extends React.Component<IAppProps, IState> {
   }
   setListener(id:string, view:"table"|"map", f:FeatureListener) {
     if (this.state === null) return;
-    if (this.state.listeners[id] === undefined) {
-      this.state.listeners[id] = {map: undefined, table: undefined};
+    if (this.state.featureListeners[id] === undefined) {
+      this.state.featureListeners[id] = {map: undefined, table: undefined};
     }
-    this.state.listeners[id][view] = f;
-    //this.setState({listeners: {...this.state.listeners, [id]: {...this.state.listeners[id], [view]: f}}});
+    this.state.featureListeners[id][view] = f;
   }
   setFromJson(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) {
     const flattened = getFeatures(json);

--- a/src/dataContext.tsx
+++ b/src/dataContext.tsx
@@ -24,17 +24,24 @@ export function getValueFromUpdaterOrValue<T>(updaterOrValue:UpdaterOrValue<T>, 
   }
 }
 
+export type FeatureListener = (feature:GeoJson.Feature) => void;
+export type FeatureListenerTable = {
+  [id:string]: {table: FeatureListener|undefined, map: FeatureListener|undefined}
+}
+
 export type DataContextType = {
   data: GeoJson.Feature[],
   filter: any, // TODO define filter type
   filteredData: GeoJson.Feature[],
   columns: Column[],
   symbology: Symbology | null,
+  listeners: FeatureListenerTable,
   setData: {(updaterOrValue:UpdaterOrValue<GeoJson.Feature[]>) : void},
   setFilter: {(newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setDataAndFilter: {(newData:UpdaterOrValue<GeoJson.Feature[]>, newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setColumns: {(newColumns:UpdaterOrValue<Column[]>) : void},
   setSymbology: {(newSymbology:UpdaterOrValue<Symbology|null>) : void},
+  setListener: {(id:string, view:"table"|"map", f:FeatureListener)}
   setFromJson: {(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) : void},
 } | null;
 

--- a/src/dataContext.tsx
+++ b/src/dataContext.tsx
@@ -35,13 +35,13 @@ export type DataContextType = {
   filteredData: GeoJson.Feature[],
   columns: Column[],
   symbology: Symbology | null,
-  listeners: FeatureListenerTable,
+  featureListeners: FeatureListenerTable,
   setData: {(updaterOrValue:UpdaterOrValue<GeoJson.Feature[]>) : void},
   setFilter: {(newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setDataAndFilter: {(newData:UpdaterOrValue<GeoJson.Feature[]>, newFilter:UpdaterOrValue<ConditionGroup|undefined>) : void},
   setColumns: {(newColumns:UpdaterOrValue<Column[]>) : void},
   setSymbology: {(newSymbology:UpdaterOrValue<Symbology|null>) : void},
-  setListener: {(id:string, view:"table"|"map", f:FeatureListener)}
+  setFeatureListener: {(id:string, view:"table"|"map", f:FeatureListener)}
   setFromJson: {(json:GeoJson.FeatureCollection & {geotabMetadata:GeotabMetadata}) : void},
 } | null;
 

--- a/src/dataview.js
+++ b/src/dataview.js
@@ -37,7 +37,6 @@ function ImportView(props) {
   const clearData = () => {
     context.setDataAndFilter([], null);
     context.setColumns([]);
-    context.setActive(null);
     context.setSymbology(null);
   }
   const simplifyGeometry = () => {

--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -154,7 +154,6 @@ export function GoogleLogin(props) {
     setOpenFile(null);
     context.setDataAndFilter([], null);
     context.setColumns([]);
-    context.setActive(null);
     context.setSymbology(null);
   }
 

--- a/src/mapview.js
+++ b/src/mapview.js
@@ -7,7 +7,7 @@ import {DataContext} from './dataContext'
 import {getCentralCoord, hashCode, getFeatureListBounds} from './algorithm'
 import mapLayers from './maplayers'
 import {painter} from './painter'
-import {onMouseOver, onMouseOut, onMouseClick, addHover, removeHover, toggleActive} from './selection'
+import {addHover, removeHover, toggleActive} from './selection'
 
 function MapView(props) {
     const context = useContext(DataContext);
@@ -37,27 +37,25 @@ function MapView(props) {
             <GeoJSON data={features} key={hashCode(JSON.stringify(features))} style={painter(context.symbology)}
             pointToLayer={painter(context.symbology)}
             onEachFeature={(feature, layer) => {
-              context.setListener(feature.id, "map", restyleLayer.bind(null, layer))
+              context.setFeatureListener(feature.id, "map", restyleLayer.bind(null, layer))
               layer.once({
                 mouseover: (e) => {
                   feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
                   restyleLayer(e.target, feature);
-                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  const tableListener = context?.featureListeners[feature.id]?.["table"];
                   if (tableListener !== undefined) {
                     tableListener(feature);
                   }
-                  //context.setData(onMouseOver.bind(null,feature.id));
                 },
               })
               layer.on({
                 click: (e) => {
                   feature.properties["geotab:selectionStatus"] = toggleActive(feature.properties["geotab:selectionStatus"]);
                   restyleLayer(e.target, feature);
-                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  const tableListener = context?.featureListeners[feature.id]?.["table"];
                   if (tableListener !== undefined) {
                     tableListener(feature);
                   }
-                  //context.setData(onMouseClick.bind(null,feature.id));
                 },
                 mouseout: (e) => {
                   feature.properties["geotab:selectionStatus"] = removeHover(feature.properties["geotab:selectionStatus"]);
@@ -66,18 +64,16 @@ function MapView(props) {
                     mouseover: (e) => {
                       feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
                       restyleLayer(e.target, feature);
-                      const tableListener = context?.listeners[feature.id]?.["table"];
+                      const tableListener = context?.featureListeners[feature.id]?.["table"];
                       if (tableListener !== undefined) {
                         tableListener(feature);
                       }
-                      //context.setData(onMouseOver.bind(null,feature.id));
                     },
                   });
-                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  const tableListener = context?.featureListeners[feature.id]?.["table"];
                   if (tableListener !== undefined) {
                     tableListener(feature);
                   }
-                  //context.setData(onMouseOut.bind(null,feature.id));
                 },
               })
               layer.bindPopup(

--- a/src/mapview.js
+++ b/src/mapview.js
@@ -18,7 +18,7 @@ function MapView(props) {
           resizeObserver.observe(container)
         }
       };
-      const restyleLayer = (feature, layer) => {
+      const restyleLayer = (layer, feature) => {
         const style = painter(context.symbology)(feature);
         if (layer.setStyle instanceof Function) {
           layer.setStyle(style);
@@ -37,30 +37,47 @@ function MapView(props) {
             <GeoJSON data={features} key={hashCode(JSON.stringify(features))} style={painter(context.symbology)}
             pointToLayer={painter(context.symbology)}
             onEachFeature={(feature, layer) => {
+              context.setListener(feature.id, "map", restyleLayer.bind(null, layer))
               layer.once({
                 mouseover: (e) => {
                   feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
-                  restyleLayer(feature, e.target);
-                  context.setData(onMouseOver.bind(null,feature.id));
+                  restyleLayer(e.target, feature);
+                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  if (tableListener !== undefined) {
+                    tableListener(feature);
+                  }
+                  //context.setData(onMouseOver.bind(null,feature.id));
                 },
               })
               layer.on({
                 click: (e) => {
                   feature.properties["geotab:selectionStatus"] = toggleActive(feature.properties["geotab:selectionStatus"]);
-                  restyleLayer(feature, e.target);
-                  context.setData(onMouseClick.bind(null,feature.id));
+                  restyleLayer(e.target, feature);
+                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  if (tableListener !== undefined) {
+                    tableListener(feature);
+                  }
+                  //context.setData(onMouseClick.bind(null,feature.id));
                 },
                 mouseout: (e) => {
                   feature.properties["geotab:selectionStatus"] = removeHover(feature.properties["geotab:selectionStatus"]);
-                  restyleLayer(feature, e.target);
+                  restyleLayer(e.target, feature);
                   e.target.once({
                     mouseover: (e) => {
                       feature.properties["geotab:selectionStatus"] = addHover(feature.properties["geotab:selectionStatus"]);
-                      restyleLayer(feature, e.target);
-                      context.setData(onMouseOver.bind(null,feature.id));
+                      restyleLayer(e.target, feature);
+                      const tableListener = context?.listeners[feature.id]?.["table"];
+                      if (tableListener !== undefined) {
+                        tableListener(feature);
+                      }
+                      //context.setData(onMouseOver.bind(null,feature.id));
                     },
                   });
-                  context.setData(onMouseOut.bind(null,feature.id));
+                  const tableListener = context?.listeners[feature.id]?.["table"];
+                  if (tableListener !== undefined) {
+                    tableListener(feature);
+                  }
+                  //context.setData(onMouseOut.bind(null,feature.id));
                 },
               })
               layer.bindPopup(

--- a/src/selection.tsx
+++ b/src/selection.tsx
@@ -19,25 +19,3 @@ export function toggleActive(status?:string) {
   }
   return status.includes("inactive") ? status.replace("inactive", "active") : status.replace("active", "inactive");
 }
-// Manipulate a feature list when an action occurs on a certain feature with given ID
-export function onMouseOver(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
-  return data.map(f =>
-    f.id === featureId
-    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: addHover(f.properties["geotab:selectionStatus"])}}
-    : {...f, properties: {...f.properties, ["geotab:selectionStatus"]: removeHover(f.properties["geotab:selectionStatus"])}}
-    );
-}
-export function onMouseOut(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
-  return data.map(f =>
-    f.id === featureId
-    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: removeHover(f.properties["geotab:selectionStatus"])}}
-    : f
-    );
-}
-export function onMouseClick(featureId:string, data:GeoJson.Feature[]):GeoJson.Feature[] {
-  return data.map(f =>
-    f.id === featureId
-    ? {...f, properties: {...f.properties, ["geotab:selectionStatus"]: toggleActive(f.properties["geotab:selectionStatus"])}}
-    : f
-    );
-}

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -1,10 +1,10 @@
-import {KeyboardEvent, RefObject, useContext} from 'react'
+import {KeyboardEvent, RefObject, useContext, useState} from 'react'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import DataTableCell from './DataTableCell'
 import RowContextMenu from './RowContextMenu';
 import {Column} from './../column'
 import {Feature, FeatureProperties} from './../geojson-types'
-import {onMouseOver, onMouseOut, onMouseClick} from '../selection'
+import {onMouseOver, onMouseOut, onMouseClick, toggleActive, addHover, removeHover} from '../selection'
 import {DataContext} from '../dataContext'
 
 type TableRowProps = {
@@ -20,6 +20,10 @@ type TableRowProps = {
 
 export default function TableRow(props:TableRowProps) {
   const context = useContext(DataContext);
+  const [className, setClassName] = useState("inactive");
+  if (context !== null) {
+    context.setListener(props.feature.id, "table", (f) => setClassName(f.properties["geotab:selectionStatus"]))
+  }
   const handleCellChange = (value:any, column:Column) => {
     const newFeatureProperties = {...props.feature.properties, [column.name]: value};
     props.onChange(newFeatureProperties, props.fidx);
@@ -27,10 +31,34 @@ export default function TableRow(props:TableRowProps) {
   return (
     <tr
       onContextMenu={() => console.log(props.feature)}
-      onClick={(e) => { context?.setData(onMouseClick.bind(null, props.feature.id)) }}
-      onMouseOver={(e) => { context?.setData(onMouseOver.bind(null, props.feature.id)) }}
-      onMouseOut={(e) => { context?.setData(onMouseOut.bind(null, props.feature.id)) }}
-      className={props.feature.properties["geotab:selectionStatus"]}
+      onClick={(e) => {
+        //context?.setData(onMouseClick.bind(null, props.feature.id))
+        props.feature.properties["geotab:selectionStatus"] = toggleActive(props.feature.properties["geotab:selectionStatus"]);
+        setClassName(props.feature.properties["geotab:selectionStatus"]);
+        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        if (mapListener !== undefined) {
+          mapListener(props.feature);
+        }
+      }}
+      onMouseOver={(e) => {
+        //context?.setData(onMouseOver.bind(null, props.feature.id))
+        props.feature.properties["geotab:selectionStatus"] = addHover(props.feature.properties["geotab:selectionStatus"]);
+        setClassName(props.feature.properties["geotab:selectionStatus"]);
+        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        if (mapListener !== undefined) {
+          mapListener(props.feature);
+        }
+      }}
+      onMouseOut={(e) => {
+        // context?.setData(onMouseOut.bind(null, props.feature.id))
+        props.feature.properties["geotab:selectionStatus"] = removeHover(props.feature.properties["geotab:selectionStatus"]);
+        setClassName(props.feature.properties["geotab:selectionStatus"]);
+        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        if (mapListener !== undefined) {
+          mapListener(props.feature);
+        }
+      }}
+      className={className}
       >
       <th>
         {1+props.fidx}

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -20,7 +20,7 @@ type TableRowProps = {
 
 export default function TableRow(props:TableRowProps) {
   const context = useContext(DataContext);
-  const [className, setClassName] = useState("inactive");
+  const [className, setClassName] = useState(props.feature.properties["geotab:selectionStatus"] ?? "inactive");
   if (context !== null) {
     context.setListener(props.feature.id, "table", (f) => setClassName(f.properties["geotab:selectionStatus"]))
   }

--- a/src/table/DataTableRow.tsx
+++ b/src/table/DataTableRow.tsx
@@ -4,7 +4,7 @@ import DataTableCell from './DataTableCell'
 import RowContextMenu from './RowContextMenu';
 import {Column} from './../column'
 import {Feature, FeatureProperties} from './../geojson-types'
-import {onMouseOver, onMouseOut, onMouseClick, toggleActive, addHover, removeHover} from '../selection'
+import {toggleActive, addHover, removeHover} from '../selection'
 import {DataContext} from '../dataContext'
 
 type TableRowProps = {
@@ -22,7 +22,7 @@ export default function TableRow(props:TableRowProps) {
   const context = useContext(DataContext);
   const [className, setClassName] = useState(props.feature.properties["geotab:selectionStatus"] ?? "inactive");
   if (context !== null) {
-    context.setListener(props.feature.id, "table", (f) => setClassName(f.properties["geotab:selectionStatus"]))
+    context.setFeatureListener(props.feature.id, "table", (f) => setClassName(f.properties["geotab:selectionStatus"]))
   }
   const handleCellChange = (value:any, column:Column) => {
     const newFeatureProperties = {...props.feature.properties, [column.name]: value};
@@ -32,28 +32,25 @@ export default function TableRow(props:TableRowProps) {
     <tr
       onContextMenu={() => console.log(props.feature)}
       onClick={(e) => {
-        //context?.setData(onMouseClick.bind(null, props.feature.id))
         props.feature.properties["geotab:selectionStatus"] = toggleActive(props.feature.properties["geotab:selectionStatus"]);
         setClassName(props.feature.properties["geotab:selectionStatus"]);
-        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        const mapListener = context?.featureListeners[props.feature.id]?.["map"];
         if (mapListener !== undefined) {
           mapListener(props.feature);
         }
       }}
       onMouseOver={(e) => {
-        //context?.setData(onMouseOver.bind(null, props.feature.id))
         props.feature.properties["geotab:selectionStatus"] = addHover(props.feature.properties["geotab:selectionStatus"]);
         setClassName(props.feature.properties["geotab:selectionStatus"]);
-        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        const mapListener = context?.featureListeners[props.feature.id]?.["map"];
         if (mapListener !== undefined) {
           mapListener(props.feature);
         }
       }}
       onMouseOut={(e) => {
-        // context?.setData(onMouseOut.bind(null, props.feature.id))
         props.feature.properties["geotab:selectionStatus"] = removeHover(props.feature.properties["geotab:selectionStatus"]);
         setClassName(props.feature.properties["geotab:selectionStatus"]);
-        const mapListener = context?.listeners[props.feature.id]?.["map"];
+        const mapListener = context?.featureListeners[props.feature.id]?.["map"];
         if (mapListener !== undefined) {
           mapListener(props.feature);
         }


### PR DESCRIPTION
- #46: changes now go both directions from table to map and map to table.
- #48: onMouseOver performance now fine for 1000-feature dataset.
- #51: deprecated setActive removed.