### PR TITLE
Improve json-logic operations

### DIFF
--- a/src/geojson-calc.ts
+++ b/src/geojson-calc.ts
@@ -250,7 +250,11 @@ export function pathNovelty(f:gj.Feature) : number {
 
       const noveltyPerPoint = points.map(
         (pt1, i) => points.reduce(
-          (acc, pt2, j) => Math.min(acc, i === j ? Infinity : distanceGrid[i][j] / Math.abs(cumulativeDistance[i] - cumulativeDistance[j])),
+          (acc, pt2, j) => Math.min(
+            acc,
+            i === j || cumulativeDistance[i] - cumulativeDistance[j] === 0
+              ? Infinity
+              : distanceGrid[i][j] / Math.abs(cumulativeDistance[i] - cumulativeDistance[j])),
           Infinity
         )
       );

--- a/src/json-logic/operations/geo.ts
+++ b/src/json-logic/operations/geo.ts
@@ -46,12 +46,28 @@ const distanceToPoint : OperatorBody = (feature, point) => {
   }
 }
 
+const toOutAndBack : OperatorBody = (feature, point) => {
+  switch (feature.geometry.type) {
+    case "Point":
+    case "MultiPoint":
+      throw new Error("toOutAndBack not implemented for this geometry type");
+    case "LineString":
+      return {...feature, geometry: {...feature.geometry, coordinates: feature.geometry.coordinates.concat(feature.geometry.coordinates.toReversed())}};
+    case "MultiLineString":
+    case "Polygon":
+    case "MultiPolygon":
+    case "GeometryCollection":
+      throw new Error("toOutAndBack not implemented for this geometry type");
+  }
+}
+
 export const Geo = {
   beginning,
   ending,
   novelty,
   unionMany,
   distanceToPoint,
+  toOutAndBack,
 };
 
 export default Geo;

--- a/src/json-logic/operations/index.ts
+++ b/src/json-logic/operations/index.ts
@@ -17,6 +17,7 @@ const mathOperations = getMethods(Math).map(op => `Math.${op}`);
 const geoOperaitons = getMethods(Geo).map(op => `Geo.${op}`);
 
 const jsonLogicOperations = [
+  "log",
   "var",
   "if",
   "==",


### PR DESCRIPTION
Add json-logic default operation "log" to schema.
Fix divide-by-zero in path novelty function.
Add toOutAndBack that mirrors a LineString.