### PR TITLE
Fix ID change to OSM layer

### DIFF
--- a/src/mapview.js
+++ b/src/mapview.js
@@ -200,7 +200,7 @@ function ChangeView() {
     {
       baseLayers: mapLayers.baseLayers.map((layer, index) => ({
         ...layer,
-        checked: (urlParams.get("b") ?? "om") === layer.geotabId
+        checked: (urlParams.get("b") ?? "osm") === layer.geotabId
       })),
       overlays: mapLayers.overlays.map((layer, index) => ({
         ...layer,


### PR DESCRIPTION
The ID changed in the layers definition, but the code needs to change as well in order to default the layer selection to OSM.