### PR TITLE
Add BLM SMA layer for public lands

### DIFF
--- a/src/maplayers.ts
+++ b/src/maplayers.ts
@@ -245,6 +245,23 @@ const overlays = [
   makeTnmBaseMap('carto', 'transportation'),
   makeTnmBaseMap('hydro', 'NHDPlus_HR'),
   makeTnmBaseMap('partnerships', 'USGSTrails'),
+  {
+    type: "WMSTileLayer",
+    name: "Public Lands",
+    geotabId: "sma",
+    checked: false,
+    layers: "show%3A22",
+    f: "image",
+    imageSR: 102100,
+    bboxSR: 102100,
+    format: "png32",
+    transparent: true,
+    opacity: 0.3,
+    dpi: 96,
+    url: "https://gis.blm.gov/arcgis/rest/services/lands/BLM_Natl_SMA_Cached_with_PriUnk/MapServer/export",
+    attribution:
+      'Map data &copy; <a href="https://gis.blm.gov/arcgis/rest/services/lands/BLM_Natl_SMA_Cached_with_PriUnk/MapServer">BLM</a>',
+  },
 ];
 
 export const mapLayers = {


### PR DESCRIPTION
Add the Surface Management Agency from the BLM, which shows public lands ownership.