### PR TITLE
Export features even when no style is selected

### DIFF
--- a/src/ExportView.jsx
+++ b/src/ExportView.jsx
@@ -148,7 +148,9 @@ export function ExportView() {
               "marker-color": color,
               "marker-symbol": markerSymbol,
             }
-          }
+          };
+        default:
+          return f;
       }
     });
 


### PR DESCRIPTION
The style switch in the export logic has no default case, so is exporting "null" for features when "geojson" format without style is selected. This patch changes it to export the features with no style info when that format is selected.